### PR TITLE
Improve doc generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ venv/
 dist/
 build/
 _build/
-_templates/
 
 
 # Logs
@@ -26,6 +25,8 @@ _templates/
 docs/source/
 Makefile
 make.bat
+docs/reference/generated/*
+docs/html/*
 
 # === OS / IDE-specific files ===
 # macOS

--- a/docs/_templates/autosummary/base.rst
+++ b/docs/_templates/autosummary/base.rst
@@ -1,0 +1,7 @@
+{{ objname | escape | underline }}
+
+Module : {{module}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,4 +55,18 @@ html_theme_options = {
             "icon": "fab fa-github",
         },
     ],
+    "logo": {
+        "text": "DEM Gen"
+    },
+    "use_edit_page_button": True,
+    "show_toc_level": 1,
+    # [left, content, right] For testing that the navbar items align properly
+    "navbar_align": "content"
+}
+
+html_context = {
+    "github_user": "ESaint-Denis",
+    "github_repo": "dem_lic",
+    "github_version": "main",
+    "doc_path": "docs",
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,14 @@
 
 Explore the documentation for the **dem_lic** package, including the command-line interface, user manual, and detailed API reference.
 
-
 ```{toctree}
-:maxdepth: 2
-:caption: Contents:
+:maxdepth: 1
+:hidden:
 
-documentation
-reference/index
+USer Guide <documentation>
+API reference <reference/index>
 ```
+
 [Methodological Documentation: DEM Generalization with Line Integral Convolution](./_static/Methodological_Documentation_DEM_Generalization_with_Line_Integral_Convolution.pdf) 📄
 
 ## Indices and tables

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,12 @@
+---
+myst:
+  html_meta:
+    "description lang=en": |
+      Top-level documentation for DEM Generalization with LIC, with links to the rest
+      of the site..
+html_theme.sidebar_secondary.remove: true
+---
+
 # Welcome to dem_lic's documentation!
 
 Explore the documentation for the **dem_lic** package, including the command-line interface, user manual, and detailed API reference.
@@ -6,7 +15,7 @@ Explore the documentation for the **dem_lic** package, including the command-lin
 :maxdepth: 1
 :hidden:
 
-USer Guide <documentation>
+User Guide <documentation>
 API reference <reference/index>
 ```
 

--- a/docs/reference/generated/lic_extended.extended_lic_weighted_altitude_lengthModulated.rst
+++ b/docs/reference/generated/lic_extended.extended_lic_weighted_altitude_lengthModulated.rst
@@ -1,6 +1,0 @@
-﻿lic\_extended.extended\_lic\_weighted\_altitude\_lengthModulated
-================================================================
-
-.. currentmodule:: lic_extended
-
-.. autofunction:: extended_lic_weighted_altitude_lengthModulated

--- a/docs/reference/generated/lic_extended.process_geotiff_in_block_with_overlap.rst
+++ b/docs/reference/generated/lic_extended.process_geotiff_in_block_with_overlap.rst
@@ -1,6 +1,0 @@
-﻿lic\_extended.process\_geotiff\_in\_block\_with\_overlap
-========================================================
-
-.. currentmodule:: lic_extended
-
-.. autofunction:: process_geotiff_in_block_with_overlap

--- a/docs/reference/generated/lic_extended.process_lic_extended.rst
+++ b/docs/reference/generated/lic_extended.process_lic_extended.rst
@@ -1,6 +1,0 @@
-﻿lic\_extended.process\_lic\_extended
-====================================
-
-.. currentmodule:: lic_extended
-
-.. autofunction:: process_lic_extended

--- a/docs/reference/generated/morpho_dem.calculate_maximal_curvature.rst
+++ b/docs/reference/generated/morpho_dem.calculate_maximal_curvature.rst
@@ -1,6 +1,0 @@
-﻿morpho\_dem.calculate\_maximal\_curvature
-=========================================
-
-.. currentmodule:: morpho_dem
-
-.. autofunction:: calculate_maximal_curvature

--- a/docs/reference/generated/morpho_dem.fast_adaptive_gaussian_blur.rst
+++ b/docs/reference/generated/morpho_dem.fast_adaptive_gaussian_blur.rst
@@ -1,6 +1,0 @@
-﻿morpho\_dem.fast\_adaptive\_gaussian\_blur
-==========================================
-
-.. currentmodule:: morpho_dem
-
-.. autofunction:: fast_adaptive_gaussian_blur

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,8 +12,8 @@ Documentation of the APIs located in the dem_lic.utils folder
     :nosignatures:
     :toctree: generated
 
-    calculate_maximal_curvature
     fast_adaptive_gaussian_blur
+    calculate_maximal_curvature
 ```
 
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,37 +1,44 @@
 # API Reference
+
 Documentation of the APIs located in the dem_lic.utils folder
 
 
 ## Geomorphometry functions
 
 ```{eval-rst}
+.. currentmodule:: morpho_dem
+
 .. autosummary::
     :nosignatures:
     :toctree: generated
 
-    morpho_dem.calculate_maximal_curvature
-    morpho_dem.fast_adaptive_gaussian_blur
+    calculate_maximal_curvature
+    fast_adaptive_gaussian_blur
 ```
 
 
 ## Line integral convolution
 
 ```{eval-rst}
+.. currentmodule:: lic_extended
+
 .. autosummary::
     :nosignatures:
     :toctree: generated
 
-    lic_extended.extended_lic_weighted_altitude_lengthModulated
-    lic_extended.process_lic_extended
+    extended_lic_weighted_altitude_lengthModulated
+    process_lic_extended
 ```
 
 
 ## block processing
 
 ```{eval-rst}
+.. currentmodule:: lic_extended
+
 .. autosummary::
     :nosignatures:
     :toctree: generated
 
-    lic_extended.process_geotiff_in_block_with_overlap
+    process_geotiff_in_block_with_overlap
 ```

--- a/src/dem_lic/utils/lic_extended.py
+++ b/src/dem_lic/utils/lic_extended.py
@@ -36,8 +36,10 @@ def extended_lic_weighted_altitude_lengthModulated(
     num_steps: int,
     sigma_modulated: bool = True
 ) -> np.ndarray:
-    """Applies a Line Integral Convolution (LIC) with a dynamically modulated integration
-    length (based on f) and a variable Gaussian kernel that reduces the influence of
+    """Applies a Line Integral Convolution (LIC) with options
+    
+    With a dynamically modulated integration length (based on f) and a
+    variable Gaussian kernel that reduces the influence of
     higher terrain along the line of integration.
     
     Parameters
@@ -194,8 +196,9 @@ def LIC_iterations(
     sigma: float,
     k: float,
 ) -> np.ndarray:
-    """Perform multiple iterations of the Line Integral Convolution (LIC) method to generalize a DEM
-    by combining smoothing and feature enhancement.
+    """Perform multiple iterations of the Line Integral Convolution (LIC) 
+    
+    method used to generalize a DEM by combining smoothing and feature enhancement.
 
     Parameters
     ----------
@@ -227,6 +230,7 @@ def LIC_iterations(
     Notes
     -----
     This function performs the following steps for each iteration:
+
     1. Computes a modulated LIC 
     2. Calculates the maximal curvature of the resulting grid.
     3. Applies Gaussian smoothing to the curvature.

--- a/src/dem_lic/utils/morpho_dem.py
+++ b/src/dem_lic/utils/morpho_dem.py
@@ -12,7 +12,7 @@ def calculate_maximal_curvature(
         dem: np.ndarray,
         resolution: float = 1
 ) -> np.ndarray:
-    """Compute the maximal curvature (k_max) of a DEM using vectorized calculations.
+    """Compute the maximal curvature (k_max) of a DEM using vectorized calculations
 
     Parameters
     ----------
@@ -29,14 +29,16 @@ def calculate_maximal_curvature(
     Notes
     -----
     This function computes the following terms:
-    - p: dz/dx (first derivative in x direction)
-    - q: dz/dy (first derivative in y direction)
-    - r: d²z/dx² (second derivative in x direction)
-    - t: d²z/dy² (second derivative in y direction)
-    - s: d²z/dxdy (second mixed derivative)
+    
+    - **p**: (first derivative in x direction) :math:`\\frac{\\partial z}{\\partial x}`
+    - **q**: dz/dy (first derivative in y direction)
+    - **r**: d²z/dx² (second derivative in x direction)
+    - **t**: d²z/dy² (second derivative in y direction)
+    - **s**: d²z/dxdy (second mixed derivative)
 
     The maximal curvature is then computed as:
     k_max = H + sqrt(H² - K)
+    
     where:
     H = -((1 + q²)r - 2pqs + (1 + p²)t) / (2 * (1 + p² + q²)^(3/2))
     K = (rt - s²) / (1 + p² + q²)²
@@ -78,7 +80,11 @@ def fast_adaptive_gaussian_blur(
     sigma_max: float,
     num_bins: int = 10,
 ) -> np.ndarray:
-    """Applies a fast adaptive Gaussian blur by grouping pixels into bins based on local curvature values.
+    """Compute a fast approximation of adaptive Gaussian blur.
+    
+    the computation is done bu grouping pixels into bins based on local curvature values,
+    follow by an interpolation between bin value to approximate an exact adaptative
+    gaussian blur.
 
     Parameters
     ----------
@@ -101,6 +107,7 @@ def fast_adaptive_gaussian_blur(
     Notes
     -----
     The function performs the following steps:
+
     1. Calculates the sigma value for each pixel based on the local curvature, limited by `sigma_max`.
     2. Groups pixels into bins according to their sigma values.
     3. Applies a Gaussian blur for each bin using a fixed sigma value.
@@ -159,8 +166,9 @@ def initialize_flat_steep_grid(
         slope_threshold: float,
         cellsize: float
 ) -> np.ndarray:
-    """Creates a binary grid to distinguish flat and steep areas based on slope
-    calculated from the DEM.
+    """Creates a binary grid to distinguish flat and steep areas 
+    
+    The computation i based on slope calculated from the input DEM.
 
     Parameters
     ----------
@@ -200,8 +208,8 @@ def remove_small_flat_areas(
         flat_steep_grid: np.ndarray,
         min_area: int
 ) -> np.ndarray:
-    """Removes small flat areas from a binary grid by replacing regions smaller
-    than the specified threshold with steep areas.
+    """Removes small flat areas from a binary grid 
+    
 
     Parameters
     ----------


### PR DESCRIPTION
Some change to improve the documentation rendering :

First for the doc configuration :
- add docs/reference/generated to .gitignore and remove existing auto-generated file.
- add _template for autosummary directive. This template is taken from numpy and help to remove module name when documenting function. (long function name to short function name)
- add an option (yalm matter) in first page to remove sidebar
- add option to sphinx config (conf.py) for pydat theme : center navbar and rename logo text. 

Add for the documentation/docstring
- debug some reSt syntax of docstring for list (missing blankline)
- Keep a short first docstring line in function for function short summary (for display in table)